### PR TITLE
Procesar validaciones por expediente

### DIFF
--- a/src/data_access/imp/postgres_reader/postgres_reader.py
+++ b/src/data_access/imp/postgres_reader/postgres_reader.py
@@ -10,6 +10,82 @@ from sqlalchemy import String
 from data_access.interface import IDataReader
 
 
+EXPEDIENTES = [
+    "LAM0237",
+    "LAM4037",
+    "LAM0112",
+    "LAM2583",
+    "LAM2577",
+    "LAM2142",
+    "LAM3575",
+    "LAM3823",
+    "LAM2578",
+    "LAM2575",
+    "LAM2574",
+    "LAM3888",
+    "LAM2576",
+    "LAM4090",
+    "LAM0005",
+    "LAM0514",
+    "LAM1582",
+    "LAM2230",
+    "LAM2233",
+    "LAM2582",
+    "LAM2611",
+    "LAM2223",
+    "LAM0529",
+    "LAM0261",
+    "LAM4697",
+    "LAM0058",
+    "LAM2581",
+    "LAM3948",
+    "LAM3563",
+    "LAV0021-00-2021",
+    "LAM9086-00",
+    "LAV0070-00-2017",
+    "LAM1094",
+    "LAM3491",
+    "LAM2622",
+    "LAM5801",
+    "LAM3831",
+    "LAM1862",
+    "LAM5688",
+    "LAV0029-00-2016",
+    "LAM3271",
+    "LAM0027",
+    "LAM3199",
+    "LAM1748",
+    "LAM6086",
+    "LAM4031",
+    "LAM0408",
+    "LAM1203",
+    "LAV0018-00-2015",
+    "LAM1403",
+    "LAM1499",
+    "LAM6153",
+    "LAM0579",
+    "LAM0806",
+    "LAM0530",
+    "LAM0626",
+    "LAM4567",
+    "LAM2347",
+    "LAV0050-13",
+    "LAM4924",
+    "LAM1821",
+    "LAM3830",
+    "LAV0052-00-2019",
+    "LAV0002-00-2020",
+    "LAM8418-00",
+    "LAM9389-00",
+    "LAM9139-00",
+    "LAV0012-00-2023",
+    "LAM9182-00",
+    "LAV0034-00-2023",
+]
+
+expedientes = EXPEDIENTES
+
+
 class PostgresReader(IDataReader):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -23,24 +99,27 @@ class PostgresReader(IDataReader):
 
         engine = create_engine(self.pg_conn_string)
         try:
-            # Expedientes organizados alfabéticamente
-            expedientes = [
-                'LAM0237','LAM4037','LAM0112','LAM2583','LAM2577','LAM2142','LAM3575','LAM3823',
-                'LAM2578','LAM2575','LAM2574','LAM3888','LAM2576','LAM4090','LAM0005','LAM0514',
-                'LAM1582','LAM2230','LAM2233','LAM2582','LAM2611','LAM2223','LAM0529','LAM0261',
-                'LAM4697','LAM0058','LAM2581','LAM3948','LAM3563','LAV0021-00-2021','LAM9086-00',
-                'LAV0070-00-2017','LAM1094','LAM3491','LAM2622','LAM5801','LAM3831','LAM1862',
-                'LAM5688','LAV0029-00-2016','LAM3271','LAM0027','LAM3199','LAM1748','LAM6086',
-                'LAM4031','LAM0408','LAM1203','LAV0018-00-2015','LAM1403','LAM1499','LAM6153',
-                'LAM0579','LAM0806','LAM0530','LAM0626','LAM4567','LAM2347','LAV0050-13','LAM4924',
-                'LAM1821','LAM3830','LAV0052-00-2019','LAV0002-00-2020','LAM8418-00','LAM9389-00',
-                'LAM9139-00','LAV0012-00-2023','LAM9182-00','LAV0034-00-2023'
-            ]
-            stmt = text(f"""SELECT * FROM {table_name.lower()} WHERE expediente = ANY(:exp)""").bindparams(bindparam("exp", value=expedientes, type_=ARRAY(String)))
-            # stmt = text(f"SELECT * FROM {table_name.lower()}")
+            filter_values = getattr(self, "expediente", None)
+            if filter_values is None:
+                filter_values = getattr(self, "expedientes", EXPEDIENTES)
+
+            if isinstance(filter_values, str):
+                filter_values = [filter_values]
+
+            if filter_values:
+                stmt = (
+                    text(
+                        f"""SELECT * FROM {table_name.lower()} WHERE expediente = ANY(:exp)"""
+                    )
+                    .bindparams(
+                        bindparam("exp", value=filter_values, type_=ARRAY(String))
+                    )
+                )
+            else:
+                stmt = text(f"SELECT * FROM {table_name.lower()}")
             df = pd.read_sql_query(stmt, con=engine)
             if "geometry" in df.columns:
-                
+
                 geom_series = df["geometry"]
 
                 # Caso A: ya vienen como objetos shapely (tienen atributo geom_type)

--- a/src/main.py
+++ b/src/main.py
@@ -2,10 +2,10 @@ import os
 import pickle
 
 from dotenv import load_dotenv
-import geopandas as gpd
 
 from engine.validation_engine import ValidationEngine
-from rule_access.imp.database_reader.config import Base, SessionManager
+from data_access.imp.postgres_reader.postgres_reader import EXPEDIENTES
+from rule_access.imp.database_reader.config import SessionManager
 from rule_access.imp.database_reader.models.thematic import Thematic
 
 
@@ -18,35 +18,32 @@ def validate_data(
     return validation_engine.run()
 
 
-def save_data(dict_data, out_folder, thematic_name):
-    for keys, data in dict_data.items():
-        if isinstance(data, gpd.GeoDataFrame):
-            try:
-                data.to_file(os.path.join(out_folder, f"{keys}.shp"))
-            except Exception as e:
-                data.to_csv(os.path.join(out_folder, f"{keys}.csv"))
-                data.to_excel(os.path.join(out_folder, f"{keys}.xlsx"), engine='openpyxl')
-        else:
-            data.to_csv(os.path.join(out_folder, f"{keys}.csv"))
-            data.to_excel(os.path.join(out_folder, f"{keys}.xlsx"), engine='openpyxl')
-
-    with open(os.path.join(out_folder, f"data_{thematic_name}.pkl"), "wb") as f:
+def save_data(dict_data, out_folder, expediente_name):
+    os.makedirs(out_folder, exist_ok=True)
+    with open(os.path.join(out_folder, f"{expediente_name}.pkl"), "wb") as f:
         pickle.dump(dict_data, f)
-    
+
 if __name__ == "__main__":
-    
+
     load_dotenv()
     pg_conn_string = os.getenv("PG_DATABASE_URL")
     out_folder = r"D:\Codigos CM\programa_compilacion\areas_compiladas\luisa"
-    thematics = SessionManager().get_session().query(Thematic).all()
-    for thematic in thematics:
+    session = SessionManager().get_session()
+    thematics = session.query(Thematic).all()
 
-        print(thematic.group_name)
-        data = validate_data(
-            thematic.group_name,
-            "database_rule_reader",
-            "delete_strategy",
-            "postgres_reader",
-            pg_conn_string=pg_conn_string,
-        )
-        save_data(data, out_folder, thematic.group_name)
+    for expediente in EXPEDIENTES:
+        print(f"Procesando expediente: {expediente}")
+        expediente_data = {}
+        for thematic in thematics:
+            print(thematic.group_name)
+            data = validate_data(
+                thematic.group_name,
+                "database_rule_reader",
+                "delete_strategy",
+                "postgres_reader",
+                pg_conn_string=pg_conn_string,
+                expediente=expediente,
+            )
+            expediente_data[thematic.group_name] = data
+
+        save_data(expediente_data, out_folder, expediente)


### PR DESCRIPTION
## Summary
- expose the expedientes list from the Postgres reader and allow filtering data by a single expediente when provided
- iterate all expedientes in the main script, running every thematic validation for each expediente and aggregating the results
- persist only pickle files per expediente in the output folder, creating one artifact per processed expediente

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cf5a219f98832eaab233b5a3adf0ee